### PR TITLE
feat: add health check server for container monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,36 @@
-# --- Этап 1: Сборка приложения (Builder) ---
-  FROM golang:1.21-alpine AS builder
+# --- Stage 1: Build the application (Builder) ---
+# Use the official Go image for compilation.
+FROM golang:1.21-alpine AS builder
 
-  WORKDIR /app
-  
-  COPY go.mod go.sum ./
-  RUN go mod download
-  
-  COPY . .
-  
-  # Собираем статичный бинарный файл
-  RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /runner main.go
-  
-  
-  # --- Этап 2: Финальный образ (Runner) ---
-  # Используем distroless образ, который содержит только наше приложение и его зависимости.
-  # Он не содержит shell, менеджера пакетов и других утилит.
-  FROM gcr.io/distroless/static-debian11
-  
-  # Копируем системные сертификаты для HTTPS. Distroless их не имеет по умолчанию.
-  COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-  
-  # Копируем наш скомпилированный бинарный файл.
-  COPY --from=builder /runner /runner
-  
-  # Указываем команду для запуска.
-  ENTRYPOINT ["/runner"]
+# Set the working directory inside the container.
+WORKDIR /app
+
+# Copy dependency files and download them.
+# This is cached to avoid re-downloading on every code change.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build a statically-linked, optimized binary.
+# -ldflags="-w -s" strips debug information to reduce binary size.
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /runner main.go
+
+
+# --- Stage 2: Final Image (Runner) ---
+# Use a distroless image that contains common utilities like curl/wget.
+# It's minimal, secure, and doesn't rely on Alpine's musl.
+FROM gcr.io/distroless/cc-debian11
+
+# Copy the compiled binary from the builder stage.
+COPY --from=builder /runner /runner
+
+# Add a HEALTHCHECK that queries our built-in HTTP health endpoint.
+# This is more reliable than checking for a process ID.
+# `wget` is used as it's available in this base image.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD wget -qO- http://localhost:8081/healthz || exit 1
+
+# Specify the command to run when the container starts.
+ENTRYPOINT ["/runner"]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module generic-cron-runner
+module github.com/darmat1/easypanel-cron
 
 go 1.21
 


### PR DESCRIPTION
Implement a lightweight HTTP server to respond to Docker health checks on port 8081. Update Dockerfile to use distroless/cc-debian11 base image and include healthcheck configuration. Rename go module to reflect new repository location.